### PR TITLE
Instrumented test rendering of partials fixed in Django 6.0 beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+# Resolved in 6.0 beta
+
 ## Demo app to replicate django-template-partials issue
 
 ### run `pytest` or `manage.py test` to replicate

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-django==5.1
-pytest==8.3.2
-pytest-django==4.8.0
-django-template-partials==24.4
+django==6.0a1
+pytest==8.4.2
+pytest-django==4.11.1

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,5 +1,3 @@
-{% load partials %}
-
 <!DOCTYPE html>
 <html lang="en">
 <head>
@@ -7,7 +5,7 @@
     <title>Title</title>
 </head>
 <body>
-{% partialdef test_partial inline=True %}
+{% partialdef test_partial inline %}
     <h1>I am the partial.</h1>
 {% endpartialdef test_partial %}
 </body>

--- a/test_partials/settings.py
+++ b/test_partials/settings.py
@@ -38,7 +38,6 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'demo_app.apps.DemoAppConfig',
-    'template_partials',
 ]
 
 MIDDLEWARE = [


### PR DESCRIPTION
The merge of django_template_partials into Django 6.0 has resolved this issue